### PR TITLE
AGP alpha to 7.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0-alpha07' apply false
-    id 'com.android.library' version '7.3.0-alpha07' apply false
+    id 'com.android.application' version '7.2.1' apply false
+    id 'com.android.library' version '7.2.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.20-M1' apply false
 }


### PR DESCRIPTION
The project is using an incompatible version (AGP 7.3.0-alpha07) of the Android Gradle plugin. Latest supported version is AGP 7.2.1